### PR TITLE
self hosted runner

### DIFF
--- a/infrastructure/server-setup/self-hosted-runner.yml
+++ b/infrastructure/server-setup/self-hosted-runner.yml
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# OpenCRVS is also distributed under the terms of the Civil Registration
+# & Healthcare Disclaimer located at http://opencrvs.org/license.
+#
+# Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+---
+- hosts: docker-manager-first
+  become: yes
+  tasks:
+  - name: Check if OpenCRVS runner is already installed
+    shell: |
+      if systemctl list-units --full --all | grep -q 'actions.runner'; then
+        echo "installed"
+      else
+        echo "not_installed"
+      fi
+    register: runner_status
+    changed_when: false
+
+  - name: Run runner installation
+    when: runner_status.stdout == "not_installed"
+    shell: |
+      curl -sfL https://raw.githubusercontent.com/opencrvs/infrastructure/refs/heads/develop/scripts/bootstrap/opencrvs-bootstrap.sh \
+      -o opencrvs-bootstrap.sh && \
+      bash opencrvs-bootstrap.sh --owner {{ target_repo_owner }} \
+            --repo {{ target_repo_name }} \
+            --env {{ docker_swarm_env }} \
+            --token {{ migration_token }} \
+            --enable-runner


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
