### PR TITLE
Ocrvs-12930: Ensure network errors between Pankajland and SPC Portal are logged and can be re-run

### DIFF
--- a/infrastructure/postgres/setup-spc-coding.sh
+++ b/infrastructure/postgres/setup-spc-coding.sh
@@ -62,7 +62,9 @@ CREATE TABLE IF NOT EXISTS spc.coding (
   processed_by_system TIMESTAMPTZ NULL
 );
 
--- Records of death registrations that failed to reach the SPC portal
+-- Records of death registrations that failed to reach the SPC portal, retried
+-- until they succeed or are manually discarded. A row is deleted once its
+-- retry succeeds; see src/api/spc-coding/retryQueue.ts.
 CREATE TABLE IF NOT EXISTS spc.outbound_retry_queue (
   event_id TEXT PRIMARY KEY,
   tracking_id TEXT,

--- a/infrastructure/postgres/setup-spc-coding.sh
+++ b/infrastructure/postgres/setup-spc-coding.sh
@@ -62,6 +62,17 @@ CREATE TABLE IF NOT EXISTS spc.coding (
   processed_by_system TIMESTAMPTZ NULL
 );
 
+-- Records of death registrations that failed to reach the SPC portal
+CREATE TABLE IF NOT EXISTS spc.outbound_retry_queue (
+  event_id TEXT PRIMARY KEY,
+  tracking_id TEXT,
+  payload TEXT NOT NULL,
+  attempts INT NOT NULL DEFAULT 1,
+  last_error TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_attempted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
 GRANT USAGE ON SCHEMA spc TO "$SPC_POSTGRES_USER";
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA spc TO "$SPC_POSTGRES_USER";

--- a/src/api/events/handler.ts
+++ b/src/api/events/handler.ts
@@ -23,7 +23,7 @@ import {
   causeOfDeathFields,
   extractCodFields,
   getSpcCompatibleEventDocument,
-  sendRecordToSpcPortal
+  sendRecordToSpcPortalOrEnqueue
 } from '../spc-coding/utils'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -78,7 +78,7 @@ export async function onCorrectionHandler(
         mergedDeclaration
       )
 
-      await sendRecordToSpcPortal(spcCompatibleEventDocument)
+      await sendRecordToSpcPortalOrEnqueue(spcCompatibleEventDocument)
     }
   }
   return h.response().code(200)
@@ -126,7 +126,7 @@ export async function onNotificationHandler(
       eventWithAcceptedNotifyAction,
       notificationDeclaration
     )
-    await sendRecordToSpcPortal(spcCompatibleEventDocument)
+    await sendRecordToSpcPortalOrEnqueue(spcCompatibleEventDocument)
   } else {
     console.log(
       'Notification declaration is missing required fields or symptoms, skipping sending to SPC'

--- a/src/api/registration/index.ts
+++ b/src/api/registration/index.ts
@@ -23,7 +23,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { sendInformantNotification } from '../notification/informantNotification'
 import {
   getSpcCompatibleEventDocument,
-  sendRecordToSpcPortal
+  sendRecordToSpcPortalOrEnqueue
 } from '../spc-coding/utils'
 
 export interface ActionConfirmationRequest extends Hapi.Request {
@@ -96,7 +96,7 @@ export async function onRegisterHandler(
         event,
         declaration
       )
-      await sendRecordToSpcPortal(spcCompatibleEventDocument)
+      await sendRecordToSpcPortalOrEnqueue(spcCompatibleEventDocument)
     }
   }
 

--- a/src/api/spc-coding/handler.ts
+++ b/src/api/spc-coding/handler.ts
@@ -1,6 +1,7 @@
 import { getClient } from './postgres'
 import { sql } from 'kysely'
 import Hapi from '@hapi/hapi'
+import { processSpcRetryQueue } from './retryProcessor'
 import { getRetryQueueEntries } from './retryQueue'
 
 type SpcCodingDatabaseRecord = {
@@ -192,6 +193,23 @@ export async function getRetryQueueHandler(
   } catch (err) {
     request.log(['error'], err)
 
+    return h.response({ error: 'Internal server error' }).code(500)
+  }
+}
+
+/*
+ * Manually triggers a retry pass over all queued failed SPC submissions, so
+ * an operator doesn't have to wait after fixing an SPC outage.
+ */
+export async function processRetryQueueHandler(
+  request: Hapi.Request,
+  h: Hapi.ResponseToolkit
+) {
+  try {
+    const result = await processSpcRetryQueue()
+    return h.response(result).code(200)
+  } catch (err) {
+    request.log(['error'], err)
     return h.response({ error: 'Internal server error' }).code(500)
   }
 }

--- a/src/api/spc-coding/handler.ts
+++ b/src/api/spc-coding/handler.ts
@@ -1,6 +1,7 @@
 import { getClient } from './postgres'
 import { sql } from 'kysely'
 import Hapi from '@hapi/hapi'
+import { getRetryQueueEntries } from './retryQueue'
 
 type SpcCodingDatabaseRecord = {
   trackingId: string
@@ -160,6 +161,34 @@ export async function markSpcCodingProcessedHandler(
         results: updatedRows
       })
       .code(200)
+  } catch (err) {
+    request.log(['error'], err)
+
+    return h.response({ error: 'Internal server error' }).code(500)
+  }
+}
+
+/*
+ * Lists death registrations that failed to reach the SPC portal and are
+ * awaiting retry. `payload` is intentionally omitted from the response
+ */
+export async function getRetryQueueHandler(
+  request: Hapi.Request,
+  h: Hapi.ResponseToolkit
+) {
+  try {
+    const entries = await getRetryQueueEntries()
+
+    const results = entries.map((entry) => ({
+      eventId: entry.eventId,
+      trackingId: entry.trackingId,
+      attempts: entry.attempts,
+      lastError: entry.lastError,
+      createdAt: entry.createdAt,
+      lastAttemptedAt: entry.lastAttemptedAt
+    }))
+
+    return h.response({ results }).code(200)
   } catch (err) {
     request.log(['error'], err)
 

--- a/src/api/spc-coding/handler.ts
+++ b/src/api/spc-coding/handler.ts
@@ -2,7 +2,10 @@ import { getClient } from './postgres'
 import { sql } from 'kysely'
 import Hapi from '@hapi/hapi'
 import { processSpcRetryQueue } from './retryProcessor'
-import { getRetryQueueEntries } from './retryQueue'
+import {
+  deleteRetryQueueEntryByEventId,
+  getRetryQueueEntries
+} from './retryQueue'
 
 type SpcCodingDatabaseRecord = {
   trackingId: string
@@ -197,10 +200,6 @@ export async function getRetryQueueHandler(
   }
 }
 
-/*
- * Manually triggers a retry pass over all queued failed SPC submissions, so
- * an operator doesn't have to wait after fixing an SPC outage.
- */
 export async function processRetryQueueHandler(
   request: Hapi.Request,
   h: Hapi.ResponseToolkit
@@ -208,6 +207,25 @@ export async function processRetryQueueHandler(
   try {
     const result = await processSpcRetryQueue()
     return h.response(result).code(200)
+  } catch (err) {
+    request.log(['error'], err)
+    return h.response({ error: 'Internal server error' }).code(500)
+  }
+}
+
+export async function deleteRetryQueueEntryHandler(
+  request: Hapi.Request<{ Params: { eventId: string } }>,
+  h: Hapi.ResponseToolkit<{ Params: { eventId: string } }>
+) {
+  const { eventId } = request.params
+  try {
+    const entry = await deleteRetryQueueEntryByEventId(eventId)
+    if (!entry) {
+      return h
+        .response({ error: `No retry queue entry found for event ${eventId}` })
+        .code(404)
+    }
+    return h.response({ result: entry }).code(200)
   } catch (err) {
     request.log(['error'], err)
     return h.response({ error: 'Internal server error' }).code(500)

--- a/src/api/spc-coding/retryProcessor.ts
+++ b/src/api/spc-coding/retryProcessor.ts
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { logger } from '@countryconfig/logger'
+import { postSpcRecord } from './utils'
+import {
+  deleteRetryQueueEntryByEventId,
+  getRetryQueueEntries,
+  upsertFailedSubmission
+} from './retryQueue'
+
+// A possibly corrupt record stops being
+// retried after this many attempts, but stays visible via
+// GET /spc-coding/retry-queue for an admin to inspect/discard.
+const MAX_RETRY_ATTEMPTS = 10
+
+export interface RetryQueueProcessingResult {
+  skipped: boolean
+  attempted: number
+  succeeded: number
+  failed: number
+}
+
+let isRunning = false
+
+export async function processSpcRetryQueue(): Promise<RetryQueueProcessingResult> {
+  if (isRunning) {
+    return { skipped: true, attempted: 0, succeeded: 0, failed: 0 }
+  }
+
+  isRunning = true
+
+  try {
+    const entries = await getRetryQueueEntries()
+    let succeeded = 0
+    let failed = 0
+
+    for (const entry of entries) {
+      try {
+        await postSpcRecord(entry.payload)
+        await deleteRetryQueueEntryByEventId(entry.eventId)
+        succeeded++
+      } catch (error) {
+        if (entry.attempts >= MAX_RETRY_ATTEMPTS) {
+          logger.error(
+            `SPC retry queue: giving up on event ${entry.eventId} after ${entry.attempts} attempts`,
+            error
+          )
+          continue
+        }
+
+        const message = error instanceof Error ? error.message : String(error)
+        await upsertFailedSubmission(
+          entry.eventId,
+          entry.trackingId ?? '',
+          entry.payload,
+          message
+        )
+        failed++
+      }
+    }
+
+    return { skipped: false, attempted: entries.length, succeeded, failed }
+  } finally {
+    isRunning = false
+  }
+}

--- a/src/api/spc-coding/retryQueue.ts
+++ b/src/api/spc-coding/retryQueue.ts
@@ -60,3 +60,16 @@ export async function getRetryQueueEntries(): Promise<RetryQueueEntry[]> {
     lastAttemptedAt: row.lastAttemptedAt
   }))
 }
+
+export async function deleteRetryQueueEntryByEventId(
+  eventId: string
+): Promise<boolean> {
+  const db = getClient()
+
+  const result = await db
+    .deleteFrom('spc.outbound_retry_queue')
+    .where('eventId', '=', eventId)
+    .executeTakeFirst()
+
+  return Number(result.numDeletedRows) > 0
+}

--- a/src/api/spc-coding/retryQueue.ts
+++ b/src/api/spc-coding/retryQueue.ts
@@ -63,13 +63,21 @@ export async function getRetryQueueEntries(): Promise<RetryQueueEntry[]> {
 
 export async function deleteRetryQueueEntryByEventId(
   eventId: string
-): Promise<boolean> {
+): Promise<Omit<RetryQueueEntry, 'payload'> | undefined> {
   const db = getClient()
 
-  const result = await db
+  const row = await db
     .deleteFrom('spc.outbound_retry_queue')
     .where('eventId', '=', eventId)
+    .returning([
+      'eventId',
+      'trackingId',
+      'attempts',
+      'lastError',
+      'createdAt',
+      'lastAttemptedAt'
+    ])
     .executeTakeFirst()
 
-  return Number(result.numDeletedRows) > 0
+  return row
 }

--- a/src/api/spc-coding/retryQueue.ts
+++ b/src/api/spc-coding/retryQueue.ts
@@ -1,0 +1,62 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+import { sql } from 'kysely'
+import { getClient } from './postgres'
+import { EventDocument } from '@opencrvs/toolkit/events'
+
+export interface RetryQueueEntry {
+  eventId: string
+  trackingId: string | null
+  payload: EventDocument
+  attempts: number
+  lastError: string
+  createdAt: string
+  lastAttemptedAt: string
+}
+
+export async function upsertFailedSubmission(
+  eventId: string,
+  trackingId: string,
+  payload: EventDocument,
+  errorMessage: string
+) {
+  const db = getClient()
+
+  await sql`
+    INSERT INTO spc.outbound_retry_queue (event_id, tracking_id, payload, last_error)
+    VALUES (${eventId}, ${trackingId}, ${JSON.stringify(payload)}, ${errorMessage})
+    ON CONFLICT (event_id) DO UPDATE SET
+      payload = excluded.payload,
+      last_error = excluded.last_error,
+      last_attempted_at = now(),
+      attempts = spc.outbound_retry_queue.attempts + 1
+  `.execute(db)
+}
+
+export async function getRetryQueueEntries(): Promise<RetryQueueEntry[]> {
+  const db = getClient()
+
+  const rows = await db
+    .selectFrom('spc.outbound_retry_queue')
+    .selectAll()
+    .orderBy('createdAt', 'asc')
+    .execute()
+
+  return rows.map((row) => ({
+    eventId: row.eventId,
+    trackingId: row.trackingId,
+    payload: JSON.parse(row.payload) as EventDocument,
+    attempts: row.attempts,
+    lastError: row.lastError,
+    createdAt: row.createdAt,
+    lastAttemptedAt: row.lastAttemptedAt
+  }))
+}

--- a/src/api/spc-coding/utils.ts
+++ b/src/api/spc-coding/utils.ts
@@ -9,6 +9,11 @@ import {
   symptomNumber
 } from '@countryconfig/events/death/forms/pages/causeOfDeathDetails'
 import { EventDocument, FieldUpdateValue } from '@opencrvs/toolkit/events'
+import { logger } from '@countryconfig/logger'
+import {
+  deleteRetryQueueEntryByEventId,
+  upsertFailedSubmission
+} from './retryQueue'
 
 type TokenResponse = { access_token: string; token_type: string }
 
@@ -23,7 +28,7 @@ export async function getAccessToken(
 
   const url = new URL('token', countryAuthBase)
 
-  console.log('Requesting access token from:', url.toString())
+  logger.info(`Requesting access token from: ${url.toString()}`)
   const res = await fetch(url.toString(), {
     method: 'POST',
     headers: {
@@ -33,7 +38,8 @@ export async function getAccessToken(
       client_id: clientId,
       client_secret: clientSecret,
       grant_type: 'client_credentials'
-    })
+    }),
+    signal: AbortSignal.timeout(10000)
   })
   if (!res.ok)
     throw new Error(`Token request failed: ${res.status} ${await res.text()}`)
@@ -166,7 +172,7 @@ export function extractCodFields(
   )
 }
 
-export async function sendRecordToSpcPortal(event: EventDocument) {
+export async function postSpcRecord(event: EventDocument): Promise<void> {
   const spcToken = await getAccessToken(
     SPC_CLIENT_ID || '',
     SPC_CLIENT_SECRET || '',
@@ -177,20 +183,44 @@ export async function sendRecordToSpcPortal(event: EventDocument) {
     SPC_COUNTRY_CONFIG_URL
   ).toString()
 
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${spcToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(event),
+    signal: AbortSignal.timeout(10000)
+  })
+
+  logger.info(`Response status from country API: ${response.status}`)
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(
+      `Error response from country API: ${response.status} ${body}`
+    )
+  }
+}
+
+export async function sendRecordToSpcPortalOrEnqueue(
+  event: EventDocument
+): Promise<void> {
   try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${spcToken}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(event)
-    })
-    console.log('Response status from country API:', response.status)
-    if (!response.ok) {
-      console.error('Error response from country API:', await response.text())
+    await postSpcRecord(event)
+    try {
+      await deleteRetryQueueEntryByEventId(event.id)
+    } catch (dbError) {
+      logger.error('Failed to clear stale SPC retry queue entry', dbError)
     }
   } catch (error) {
-    console.error('Error sending data to country API:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error('Error sending data to country API, queueing for retry', error)
+
+    try {
+      await upsertFailedSubmission(event.id, event.trackingId, event, message)
+    } catch (dbError) {
+      logger.error('Failed to enqueue SPC submission for retry', dbError)
+    }
   }
 }

--- a/src/api/spc-coding/utils.ts
+++ b/src/api/spc-coding/utils.ts
@@ -14,6 +14,9 @@ import {
   deleteRetryQueueEntryByEventId,
   upsertFailedSubmission
 } from './retryQueue'
+import { sendEmail } from '../notification/email-service'
+import { ALERT_EMAIL, SENDER_EMAIL_ADDRESS } from '../notification/constant'
+import { applicationConfig } from '../application/application-config'
 
 type TokenResponse = { access_token: string; token_type: string }
 
@@ -222,5 +225,36 @@ export async function sendRecordToSpcPortalOrEnqueue(
     } catch (dbError) {
       logger.error('Failed to enqueue SPC submission for retry', dbError)
     }
+
+    try {
+      if (process.env.NODE_ENV === 'development') {
+        logger.info(
+          `Would send email to admin about failed record submission to the SPC portal`
+        )
+        return
+      }
+      await sendSpcDownAlertEmail(event.trackingId)
+    } catch (emailError) {
+      logger.error('Failed to send SPC-down alert email', emailError)
+    }
   }
+}
+
+export async function sendSpcDownAlertEmail(trackingId: string) {
+  const applicationName = applicationConfig.APPLICATION_NAME || 'OpenCRVS'
+  const emailBody = `
+      <p>Dear admin,</p>
+      <p>Pankajland failed to submit a record to the SPC portal.</p>
+      <ul>
+        <li>Tracking ID: ${trackingId}</li>
+      </ul>
+      <p>See the retry queue for details: GET /spc-coding/retry-queue</p>
+      <p>Best regards,<br>${applicationName}</p>
+    `
+  await sendEmail({
+    subject: 'SPC communication down — event failed to submit',
+    from: SENDER_EMAIL_ADDRESS,
+    to: ALERT_EMAIL,
+    html: emailBody
+  })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,8 @@ import {
   markSpcCodingProcessedHandler,
   getPendingSpcCodingHandler,
   getRetryQueueHandler,
-  processRetryQueueHandler
+  processRetryQueueHandler,
+  deleteRetryQueueEntryHandler
 } from './api/spc-coding/handler'
 import {
   deathRecordCorrectionNotificationHandler,
@@ -600,6 +601,16 @@ export async function createServer() {
       tags: ['api', 'spc-coding'],
       description:
         'Manually triggers the retry of all queued failed SPC submissions'
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/spc-coding/retry-queue/{eventId}',
+    handler: deleteRetryQueueEntryHandler,
+    options: {
+      tags: ['api', 'spc-coding'],
+      description: 'Discards a queued failed SPC submission'
     }
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,8 @@ import { causeOfDeathSearchHandler } from './data-seeding/reference-data/handler
 import {
   createSpcCodingHandler,
   markSpcCodingProcessedHandler,
-  getPendingSpcCodingHandler
+  getPendingSpcCodingHandler,
+  getRetryQueueHandler
 } from './api/spc-coding/handler'
 import {
   deathRecordCorrectionNotificationHandler,
@@ -576,6 +577,17 @@ export async function createServer() {
     options: {
       tags: ['api', 'spc-coding'],
       description: 'Mark SPC coding rows as processed'
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/spc-coding/retry-queue',
+    handler: getRetryQueueHandler,
+    options: {
+      tags: ['api', 'spc-coding'],
+      description:
+        'Lists death registrations that failed to reach the SPC portal and are awaiting retry'
     }
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,8 @@ import {
   createSpcCodingHandler,
   markSpcCodingProcessedHandler,
   getPendingSpcCodingHandler,
-  getRetryQueueHandler
+  getRetryQueueHandler,
+  processRetryQueueHandler
 } from './api/spc-coding/handler'
 import {
   deathRecordCorrectionNotificationHandler,
@@ -588,6 +589,17 @@ export async function createServer() {
       tags: ['api', 'spc-coding'],
       description:
         'Lists death registrations that failed to reach the SPC portal and are awaiting retry'
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/spc-coding/retry-queue/process',
+    handler: processRetryQueueHandler,
+    options: {
+      tags: ['api', 'spc-coding'],
+      description:
+        'Manually triggers the retry of all queued failed SPC submissions'
     }
   })
 


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
